### PR TITLE
fix duoble ok res at 2026-05-08

### DIFF
--- a/src/botService.ts
+++ b/src/botService.ts
@@ -42,9 +42,6 @@ const botService = async (req: Request, res: Response) => {
   const requestId = Math.random().toString(36).substring(7);
   logger.info(`[${requestId}] Webhook request received`);
 
-  // Telegram only needs an ACK for webhook delivery.
-  res.status(200).send('OK')
-
 
   const update = req.body
   const updateId: number | undefined = update.update_id


### PR DESCRIPTION
This pull request makes a small change to the `botService` handler by removing the immediate HTTP 200 response sent for Telegram webhook delivery.